### PR TITLE
fix(#144): Correcion de errores en el workflow de tests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.19.1</version>
+				<version>2.22.2</version>
 				<configuration>
 					<testFailureIgnore>true</testFailureIgnore>
 				</configuration>

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop

--- a/src/test/java/ispp_g2/gastrostock/testDueño/DueñoControllerTest.java
+++ b/src/test/java/ispp_g2/gastrostock/testDueño/DueñoControllerTest.java
@@ -14,6 +14,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -21,6 +22,7 @@ import ispp_g2.gastrostock.dueño.Dueño;
 import ispp_g2.gastrostock.dueño.DueñoController;
 import ispp_g2.gastrostock.dueño.DueñoService;
 
+@ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
 class DueñoControllerTest {
 

--- a/src/test/java/ispp_g2/gastrostock/testDueño/DueñoRepositoryTest.java
+++ b/src/test/java/ispp_g2/gastrostock/testDueño/DueñoRepositoryTest.java
@@ -6,12 +6,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import ispp_g2.gastrostock.dueño.Dueño;
 import ispp_g2.gastrostock.dueño.DueñoRepository;
 
 import java.util.Optional;
 
+@ActiveProfiles("test")
 @DataJpaTest
 @AutoConfigureTestDatabase
 class DueñoRepositoryTest {

--- a/src/test/java/ispp_g2/gastrostock/testDueño/DueñoServiceTest.java
+++ b/src/test/java/ispp_g2/gastrostock/testDueño/DueñoServiceTest.java
@@ -12,11 +12,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
 
 import ispp_g2.gastrostock.dueño.Dueño;
 import ispp_g2.gastrostock.dueño.DueñoRepository;
 import ispp_g2.gastrostock.dueño.DueñoService;
 
+@ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
 class DueñoServiceTest {
     

--- a/src/test/java/ispp_g2/gastrostock/testLineaDePedido/LineaDePedidoControllerTest.java
+++ b/src/test/java/ispp_g2/gastrostock/testLineaDePedido/LineaDePedidoControllerTest.java
@@ -18,11 +18,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import java.util.Collections;
 import java.util.List;
 
+@ActiveProfiles("test")
 class LineaDePedidoControllerTest {
 
     private MockMvc mockMvc;

--- a/src/test/java/ispp_g2/gastrostock/testLineaDePedido/LineaDePedidoRepositoryTest.java
+++ b/src/test/java/ispp_g2/gastrostock/testLineaDePedido/LineaDePedidoRepositoryTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import ispp_g2.gastrostock.empleado.Empleado;
 import ispp_g2.gastrostock.empleado.EmpleadoRepository;
@@ -30,6 +31,7 @@ import ispp_g2.gastrostock.mesa.MesaRepository;
 
 @DataJpaTest
 @AutoConfigureTestDatabase
+@ActiveProfiles("test")
 public class LineaDePedidoRepositoryTest {
 
     @Autowired

--- a/src/test/java/ispp_g2/gastrostock/testLineaDePedido/LineaDePedidoServiceTest.java
+++ b/src/test/java/ispp_g2/gastrostock/testLineaDePedido/LineaDePedidoServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,6 +17,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+@ActiveProfiles("test")
 class LineaDePedidoServiceTest {
 
     @Mock

--- a/src/test/java/ispp_g2/gastrostock/testMesa/MesaControllerTest.java
+++ b/src/test/java/ispp_g2/gastrostock/testMesa/MesaControllerTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -27,6 +28,7 @@ import ispp_g2.gastrostock.mesa.MesaController;
 import ispp_g2.gastrostock.mesa.MesaService;
 
 @ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
 class MesaControllerTest {
 
     private MockMvc mockMvc;

--- a/src/test/java/ispp_g2/gastrostock/testMesa/MesaRepositoryTest.java
+++ b/src/test/java/ispp_g2/gastrostock/testMesa/MesaRepositoryTest.java
@@ -26,6 +26,7 @@ import ispp_g2.gastrostock.pedido.Pedido;
 
 @DataJpaTest
 @AutoConfigureTestDatabase
+@ActiveProfiles("test")
 class MesaRepositoryTest {
 
     @Autowired

--- a/src/test/java/ispp_g2/gastrostock/testMesa/MesaServiceTest.java
+++ b/src/test/java/ispp_g2/gastrostock/testMesa/MesaServiceTest.java
@@ -12,11 +12,13 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.test.context.ActiveProfiles;
 
 import ispp_g2.gastrostock.mesa.Mesa;
 import ispp_g2.gastrostock.mesa.MesaRepository;
 import ispp_g2.gastrostock.mesa.MesaService;
 
+@ActiveProfiles("test")
 class MesaServiceTest {
 
     @Mock

--- a/src/test/java/ispp_g2/gastrostock/testNegocio/NegocioControllerTest.java
+++ b/src/test/java/ispp_g2/gastrostock/testNegocio/NegocioControllerTest.java
@@ -16,7 +16,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.validation.BindingResult;
@@ -28,6 +30,7 @@ import ispp_g2.gastrostock.negocio.Negocio;
 import ispp_g2.gastrostock.negocio.NegocioController;
 import ispp_g2.gastrostock.negocio.NegocioService;
 
+@ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
 class NegocioControllerTest {
 

--- a/src/test/java/ispp_g2/gastrostock/testNegocio/NegocioServiceTest.java
+++ b/src/test/java/ispp_g2/gastrostock/testNegocio/NegocioServiceTest.java
@@ -11,13 +11,14 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.test.context.ActiveProfiles;
 
 import ispp_g2.gastrostock.dueño.Dueño;
 import ispp_g2.gastrostock.negocio.Negocio;
 import ispp_g2.gastrostock.negocio.NegocioRepository;
 import ispp_g2.gastrostock.negocio.NegocioService;
 
-
+@ActiveProfiles("test")
 class NegocioServiceTest{
 
     @Mock


### PR DESCRIPTION
Correcion del workflow de test aumentando la version del plugin maven-surfire a la version 2.22.2, debido a las incompatibilidades con ./mvnw  clean test, añadido un nuevo application-test.properties para que Spring utilice esa configuracion para los test junto con la anotacion en las clases de @ActiveProfiles("test").