### PR TITLE
Feat/367

### DIFF
--- a/frontend/src/screens/perdidas/index.js
+++ b/frontend/src/screens/perdidas/index.js
@@ -12,21 +12,17 @@ function PantallaPerdidas() {
   const [showNotifications, setShowNotifications] = useState(false);
   const [showUserOptions, setShowUserOptions] = useState(false);
   const [showLogoutModal, setShowLogoutModal] = useState(false);
-  const navigate = useNavigate();
-
-  const today = new Date("08-02-2025");  // Fecha actual
-  const formattedDate = today.toISOString().split('T')[0]; // Formato YYYY-MM-DD
-  const token = localStorage.getItem("token");
-
-  
-  
+  const navigate = useNavigate();  
 
   useEffect(() => {
     const fetchCaducados = async () => {
       try {
         const negocioId = localStorage.getItem("negocioId");
-        console.log("Negocio ID:", negocioId); // Verifica que negocioId esté correcto
-        const response = await fetch(`http://localhost:8080/api/lotes/fechaCaducidad/${formattedDate}`, {
+        const fechaActual = new Date(); // Obtener la fecha actual, si quieres ver lotes en esta pantalla pon una fecha posterior a 10-10-2025
+        const formattedDate = fechaActual.toISOString().split('T')[0];
+        const token = localStorage.getItem("token");
+  
+        const response = await fetch(`http://localhost:8080/api/lotes/negocio/${negocioId}/fecha/${formattedDate}`, {
           method: "GET",
           headers: {
             "Content-Type": "application/json",
@@ -34,89 +30,31 @@ function PantallaPerdidas() {
           },
         });
   
-        console.log("Response:", response);
         if (!response.ok) {
           throw new Error("Error al obtener los lotes caducados");
         }
   
         const data = await response.json();
-        console.log("Datos recibidos desde el backend:", data); // Verifica qué datos devuelve la API
-
-        const formatearFecha = (fecha) => {
-          const d = new Date(fecha);
-          const year = d.getFullYear();
-          const month = String(d.getMonth() + 1).padStart(2, "0");
-          const day = String(d.getDate()).padStart(2, "0");
-          return `${year}-${month}-${day}`;
-        };
-        
-  
-        // Filtrar productos por negocioId y fechaCaducidad
-        const productosFiltrados = data.filter((lote) => {
-          const nombre = lote.producto.name || "Desconocido";
-          const cantidad = lote.cantidad || 0;
-          const fechaCaducidad = formatearFecha(lote.fechaCaducidad); // <-- convierte la fecha del lote
-          const restaurante = lote.reabastecimiento?.negocio?.id;
-        
-          const fechaActual = formatearFecha(new Date("09-02-2025")); // <-- convierte la fecha actual
-        
-          const fechaValida = fechaCaducidad < fechaActual; // <-- ahora es una comparación entre strings
-          const negocioValido = restaurante === parseInt(negocioId);
-        
-          console.log("Fecha caducidad:", fechaCaducidad);
-          console.log("Fecha actual:", fechaActual);
-          console.log("Fecha válida:", fechaValida);
-          console.log("Negocio válido:", negocioValido);
-        
-          return negocioValido && fechaValida;
-        });
-  
-        console.log("Productos filtrados:", productosFiltrados); // Verifica si hay productos filtrados
-  
-        if (productosFiltrados.length === 0) {
-          console.log("No se encontraron productos para esta fecha.");
-          return;
-        }
-  
-        // Agrupar los productos
-        const agrupados = {};
-        productosFiltrados.forEach((lote) => {
-          const nombre = lote.producto.name || "Desconocido";
-          const fechaCaducidad = lote.fechaCaducidad;
-          const cantidad = lote.cantidad || 0;
-  
-          if (!agrupados[nombre]) {
-            agrupados[nombre] = {
-              nombre,
-              cantidadTotal: 0,
-              fechasCaducidad: [],
-            };
-          }
-          agrupados[nombre].cantidadTotal += cantidad;
-          agrupados[nombre].fechasCaducidad.push(fechaCaducidad);
-        });
-  
-        console.log("Productos agrupados:", Object.values(agrupados)); // Verifica los productos agrupados
-  
-        setProductosCaducados(Object.values(agrupados));
+        setProductosCaducados(data);
       } catch (error) {
         console.error("Error al obtener productos caducados:", error);
       }
     };
+  
     fetchCaducados();
   }, []);
   
-  
 
   const productosFiltrados = productosCaducados
-    .filter((producto) =>
-      producto.nombre.toLowerCase().includes(filtro.toLowerCase())
-    )
-    .sort((a, b) => {
-      const nombreA = a.nombre.toLowerCase();
-      const nombreB = b.nombre.toLowerCase();
-      return ordenAscendente ? nombreA.localeCompare(nombreB) : nombreB.localeCompare(nombreA);
-    });
+  .filter((lote) =>
+    lote.producto.name.toLowerCase().includes(filtro.toLowerCase())
+  )
+  .sort((a, b) => {
+    const nombreA = a.producto.name.toLowerCase();
+    const nombreB = b.producto.name.toLowerCase();
+    return ordenAscendente ? nombreA.localeCompare(nombreB) : nombreB.localeCompare(nombreA);
+  });
+
 
     const exportarPDF = () => {
       const doc = new jsPDF();
@@ -212,22 +150,18 @@ function PantallaPerdidas() {
         </div>
 
         <div className="empleados-grid">
-          {productosFiltrados.length > 0 ? (
-            productosFiltrados.map((producto,index) => (
-              <div key={index} className="empleado-card">
-                <h3>{producto.nombre}</h3>
-                <p>Cantidad total: {producto.cantidadTotal}</p>
-                <p>Fechas de caducidad:</p>
-                <ul>
-                  {producto.fechasCaducidad.map((fecha, i) => (
-                    <li key={i}>{new Date(fecha).toLocaleDateString()}</li>
-                  ))}
-                </ul>
-              </div>
-            ))
-          ) : (
-            <p>No se encontraron productos caducados</p>
-          )}
+        {productosFiltrados.length > 0 ? (
+  productosFiltrados.map((lote, index) => (
+    <div key={index} className="empleado-card">
+      <h3>{lote.producto.name}</h3>
+      <p>Cantidad: {lote.cantidad}</p>
+      <p>Fecha de caducidad: {new Date(lote.fechaCaducidad).toLocaleDateString()}</p>
+    </div>
+  ))
+) : (
+  <p>No se encontraron productos caducados</p>
+)}
+
         </div>
 
         {showLogoutModal && (


### PR DESCRIPTION
Ya está conectada la vista de pérdidas, muestra los lotes que están caducados, puedes ordenarlos por orden alfabético ascendente o descendente y puedes exportar dicha información a pdf. Ahora mismo por la fecha que está puesta que es la actual no muestra ningún lote caducado porque en la base de datos los lotes tienen fechas posteriores al día de hoy, he puesto un mini comentario en el código para que si quieres ver lotes caducados pongas una fecha posterior a la que pone ahí en dicha línea. 